### PR TITLE
Prevent page refresh by clicking upload

### DIFF
--- a/js/enquiry.js
+++ b/js/enquiry.js
@@ -1,6 +1,7 @@
 
 $(document).ready(function() {
-  $('.fakeUpload').on('click', function() {
+  $('.fakeUpload').on('click', function(e) {
+    e.preventDefault();
     $('#file').click();
   });
   $('#file').on('change', function() {


### PR DESCRIPTION
This is hot fix. I have no idea on why that fakeUpload element exist.
