### PR TITLE
Fix UnicodeDecodeError when using blogofile build

### DIFF
--- a/_config.py
+++ b/_config.py
@@ -57,6 +57,12 @@ site.file_ignore_patterns = [
     "requirements.txt"
 ]
 
+
+def pre_build():
+    import locale
+    locale.setlocale(locale.LC_ALL, 'C')
+
+
 def post_build():
     # Preprocess the scripts and stylesheets
     subprocess.call(["npm", "install"])


### PR DESCRIPTION
Fix issue same as [blogofile issue #152](https://github.com/EnigmaCurry/blogofile/issues/152) and use `pre_build` function to solve this error.
